### PR TITLE
[WIP] Remove the word 'software' from the service description

### DIFF
--- a/docs/service-description.md
+++ b/docs/service-description.md
@@ -14,7 +14,7 @@ security researchers to receive more content.
 We do not subcontract the processing of personal data.
 We may have data recipients. An up-to-date list of data recipients is always available at <https://docs.badrap.io/privacy.html> .
 
-## The procedures in place to secure (backup) the client's material in the software service
+## The procedures in place to secure (backup) the client's material in the service
 
 We only store a minimal amount of configuration information to relay relevant messages to and from you. We design and operate the service so that encryption is used for data transfer and storage whenever possible, according to standard security practices. 
 
@@ -24,7 +24,7 @@ We backup our production database at least once per day. We store these backups 
 
 As we are serving a global audience, we may perform installations, modifications and maintenance around the clock. Typical service interruptions are minimal, lasting only a few seconds or minutes.
 
-## The location where the software service is produced
+## The location where the service is produced
 
 All data in our service is stored in data centres within the EU.
 Maintenance and management are conducted in Finland.


### PR DESCRIPTION
Got feedback which I agree with - the word "software" is redundant here.